### PR TITLE
Updated CI to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: Build Job
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
Updated the CI from Ubuntu 18 to 22 as 18 is now depreciated.